### PR TITLE
Add SlabCalc.co - free concrete calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,9 @@ Here is a list of popular web-based civil engineering software:
 ### Structure Analysis
 - [SkyCiv Engineering](https://www.skyciv.com/structural-analysis-software/) - A cloud-based structural analysis software that provides a user-friendly interface for analyzing structures.
 
+### Concrete & Construction
+- [SlabCalc.co](https://slabcalc.co) - Free concrete calculator for slabs, driveways, patios, foundations, and more. Includes volume and cost estimation.
+
 
 ## Programming Libraries
 


### PR DESCRIPTION
## What's being added

[SlabCalc.co](https://slabcalc.co) — a free web-based concrete calculator covering slabs, driveways, patios, foundations, steps, and more. Includes both volume and cost estimation.

Added under **Web Calculators** in a new `### Concrete & Construction` subsection, alongside the existing `### Structure Analysis` entry.

## Why it fits

SlabCalc.co is a purpose-built civil/construction web calculator — directly in scope for the Web Calculators section of this list. It complements SkyCiv (structural analysis) by covering the concrete estimation side of construction work.