### PR TITLE
Add 2 free web calculators (Concrete + Asphalt) under Concrete and Construction

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ Software, libraries, calculators, and resources used in civil engineering practi
 ### Concrete and Construction
 
 - [SlabCalc.co](https://slabcalc.co) - Concrete calculator for slabs, driveways, patios, foundations, volume, and cost estimation.
+- [Concrete Calculate](https://concrete-calculate.com) - Concrete volume, bag count (40/60/80 lb), weight, and 2026 cost calculator for slabs, columns, steps, and curbs. Imperial and metric.
+- [Asphalt Calculate](https://asphalt-calculate.com) - Asphalt tonnage, cost, and thickness calculator for driveways, parking lots, and paths. Supports rectangle, circle, triangle, and L-shaped areas.
 
 ## Drafting
 


### PR DESCRIPTION
Adding two free, no-signup web calculators that fit the existing **Web Calculators › Concrete and Construction** subsection (alongside SlabCalc.co):

- [Concrete Calculate](https://concrete-calculate.com) — Concrete volume, bag count (40/60/80 lb), weight, and 2026 cost estimate for slabs, columns, steps, and curbs. Reviewed against Quikrete, Sakrete, and ACI 301-20 bag-yield data. Imperial and metric.
- [Asphalt Calculate](https://asphalt-calculate.com) — Asphalt tonnage, cost, and thickness for driveways, parking lots, and paths. Supports rectangle, circle, triangle, and L-shaped areas.

Both are free, ad-supported, no signup, no email capture, and can be embedded via iframe (with attribution) on third-party sites. Format matches the existing entry (`- [Name](url) - Description.`).

Thanks for maintaining the list!