### PR TITLE
Add RoofingCalculatorHQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ Software, libraries, calculators, and resources used in civil engineering practi
 - [SlabCalc.co](https://slabcalc.co) - Concrete calculator for slabs, driveways, patios, foundations, volume, and cost estimation.
 - [Concrete Calculate](https://concrete-calculate.com) - Concrete volume, bag count (40/60/80 lb), weight, and 2026 cost calculator for slabs, columns, steps, and curbs. Imperial and metric.
 - [Asphalt Calculate](https://asphalt-calculate.com) - Asphalt tonnage, cost, and thickness calculator for driveways, parking lots, and paths. Supports rectangle, circle, triangle, and L-shaped areas.
+- [RoofingCalculatorHQ](https://roofingcalculatorhq.com) - Free roofing calculators for area, pitch, material takeoff, snow/wind load, and replacement cost estimation. Covers 10 regional markets with local code references and CC-BY 4.0 data exports.
 
 ## Drafting
 


### PR DESCRIPTION
This PR adds **RoofingCalculatorHQ** to the *Web Calculators → Concrete and Construction* subsection, alongside the existing hosted cost calculators (SlabCalc.co, Concrete Calculate, Asphalt Calculate).

**What it is:** A free, no-signup suite of roofing calculators — roof area, pitch/slope conversion, material takeoff (shingles, metal, tile, membrane), snow and wind load, and full replacement cost estimation.

**Why it fits this list:** It's a hosted web calculator for built-environment cost estimation, directly in line with the concrete and asphalt calculators already listed in this subsection. It adds a roofing dimension the section currently lacks. It also carries civil-engineering-relevant features: snow/wind structural load references and per-region building code citations (IRC/ASTM in the US, BS 5534 in the UK, AS 2050 in AU, NBC in CA, DIN/Eurocode in DE, etc.) across 10 regional markets.

**Data licensing:** The underlying cost and reference datasets (replacement costs by material, pitch reference tables, load data) are published under CC-BY 4.0, so the data is openly reusable.

No signup, no paywall — free to use.