### PR TITLE
Add BuildRefs (free construction calculators and references)

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Software, libraries, calculators, and resources used in civil engineering practi
 - [Concrete Calculator Hub](https://concreteestimatorhub.com/) - Free concrete calculators and reference guides for concrete volume, bag counts, slabs, footings, post holes, shed bases, ready-mix comparisons, and material cost planning.
 - [Asphalt Calculate](https://asphalt-calculate.com) - Asphalt tonnage, cost, and thickness calculator for driveways, parking lots, and paths. Supports rectangle, circle, triangle, and L-shaped areas.
 - [RoofingCalculatorHQ](https://roofingcalculatorhq.com) - Free roofing calculators for area, pitch, material takeoff, snow/wind load, and replacement cost estimation. Covers 10 regional markets with local code references and CC-BY 4.0 data exports.
+- [BuildRefs](https://buildrefs.com) - Free construction calculators for concrete, framing, electrical (NEC), HVAC (Manual J), structural, and earthwork, plus steel section-property tables and code guides. Each tool cites the standard it implements; no login.
 
 ## Drafting
 


### PR DESCRIPTION
Adds BuildRefs (https://buildrefs.com) — a free, no-login web reference with 239+ construction calculators, steel section-property tables, unit converters, and plain-language code guides. Each tool cites the standard it implements and shows the formula.

Placed it in the most relevant existing section and matched the list's formatting. Happy to adjust category or wording per your guidelines.