### PR TITLE
Add GeoEq to Geotechnical/Python resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ Software, libraries, calculators, and resources used in civil engineering practi
 - [Rasterio](https://rasterio.readthedocs.io/) - Reading, writing, and processing raster datasets.
 - [PySAL](https://pysal.org/) - Spatial analysis and geostatistics.
 - [PyNite](https://pynite.readthedocs.io/en/stable/) - Python finite element library for beams, frames, plates, load combinations, stability, and P-Delta analysis.
+- [GeoEq](https://github.com/geoeq/geoeq) - Onshore geotechnical workflow: soil classification, lab testing, SPT/CPT interpretation, foundation design, soil dynamics, and liquefaction analysis.
 
 ### JavaScript
 

--- a/data/resources.json
+++ b/data/resources.json
@@ -1459,7 +1459,12 @@
               "name": "PyNite",
               "url": "https://pynite.readthedocs.io/en/stable/",
               "description": "Python finite element library for beams, frames, plates, load combinations, stability, and P-Delta analysis."
-            }
+            },
+      {
+        "name": "GeoEq",
+        "url": "https://github.com/geoeq/geoeq",
+        "description": "Onshore geotechnical workflow: soil classification, lab testing, SPT/CPT interpretation, foundation design, soil dynamics, and liquefaction analysis."
+      }
           ]
         },
         {


### PR DESCRIPTION
Adds GeoEq (https://github.com/geoeq/geoeq) to the README and resources.json. GeoEq is a Python library covering soil classification, lab testing, SPT/CPT interpretation, foundation design, soil dynamics, and liquefaction analysis. Entry added to both data/resources.json and the generated README.md to keep them in sync.