### PR TITLE
Add Xarpis 2D Frame & Beam FEA calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Software, libraries, calculators, and resources used in civil engineering practi
 
 - [SkyCiv Engineering](https://www.skyciv.com/structural-analysis-software/) - Cloud-based structural analysis software.
 - [BeamGuru Beam Calculator](https://beamguru.com/beam/) - Interactive beam analysis for reactions and axial-force, shear-force, and bending-moment diagrams.
+- [Xarpis 2D Frame & Beam FEA](https://www.xarpis.com/calculators/frame-fea-2d) - Free browser-based first-order linear analysis of 2D frames, beams, columns, braces, and trusses, with reactions, force diagrams, deflections, and load-combination envelopes.
 
 ### Concrete and Construction
 

--- a/data/resources.json
+++ b/data/resources.json
@@ -848,6 +848,11 @@
               "name": "BeamGuru Beam Calculator",
               "url": "https://beamguru.com/beam/",
               "description": "Interactive beam analysis for reactions and axial-force, shear-force, and bending-moment diagrams."
+            },
+            {
+              "name": "Xarpis 2D Frame & Beam FEA",
+              "url": "https://www.xarpis.com/calculators/frame-fea-2d",
+              "description": "Free browser-based first-order linear analysis of 2D frames, beams, columns, braces, and trusses, with reactions, force diagrams, deflections, and load-combination envelopes."
             }
           ]
         },


### PR DESCRIPTION
## Summary

Adds Xarpis 2D Frame & Beam FEA to Web Calculators → Structure Analysis.

## Why it fits

- Browser-based structural analysis for 2D frames, beams, columns, braces, and trusses
- Provides support reactions, axial-force, shear-force, bending-moment, and deflection results
- Supports load combinations and governing-result envelopes
- The analysis functionality is free to use

## Validation

- Updated data/resources.json
- Regenerated README.md using python generate.py
- Confirmed that python generate.py --check passes

Disclosure: I am the creator of Xarpis.